### PR TITLE
Vscodeからコンパイル時にエラーが出る部分の修正

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,7 +21,7 @@
     "cwd": "${workspaceFolder}",
     "program": "${workspaceFolder}/${fileBasenameNoExtension}.js",
     "outFiles": [
-      "${workspaceFolder}/${ fileBasename}.js"
+      "${workspaceFolder}/${fileBasename}.js"
     ]
   }
 ]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -16,13 +16,21 @@
 // }
 
 {
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
   "version": "2.0.0",
-  "tasks": [{
-    "label": "Compile TypeScript",
-    "type": "typescript",
-    "tsconfig": "tsconfig.json",
-    "problemMatcher": [
-      "$tsc"
-    ],
-  }]
+  "tasks": [
+      {
+          "type": "typescript",
+          "tsconfig": "tsconfig.json",
+          "label": "Compile TypeScript",
+          "problemMatcher": [
+              "$tsc"
+          ],
+          "group": {
+              "kind": "build",
+              "isDefault": true
+          }
+      }
+  ]
 }


### PR DESCRIPTION
ターミナルから直打ちで`tsc`と実行する場合は通るが、Vscodeから実行するとモジュールが足りないなど言われコンパイルが通せない状態になってしまったので修正